### PR TITLE
Database Fix

### DIFF
--- a/app/src/main/java/uk/ac/coventry/a260ct/orks/slopemanager/RegisteringActivity.java
+++ b/app/src/main/java/uk/ac/coventry/a260ct/orks/slopemanager/RegisteringActivity.java
@@ -39,6 +39,7 @@ public class RegisteringActivity extends AppCompatActivity {
     private SendInfo callback4;
     private TabLayout tabLayout;
     private String userType;
+    private int paid=-1;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -75,12 +76,7 @@ public class RegisteringActivity extends AppCompatActivity {
                 switch (curFragment.getArguments().getString("TAG")) {
                     case "AboutYouFragment":
                         callback1 = (UpdateInfo) curFragment;
-                        callback1.sendHashMap("AboutYouFragment", masterInfo);
-                        callback1.showInfo(masterInfo);
-                        break;
-                    case "MembershipPayment":
-                       // callback2 = (UpdateInfo) mSectionsPagerAdapter.getItem(tabLayout.getSelectedTabPosition());
-                      //  callback2.setInfo(tab.getPosition(), allergensInfo, foodTypePref);
+                        callback1.setInfo("AboutYouFragment", masterInfo);
                         break;
                     case "LoginDetailsFragment":
                         callback3 = (UpdateInfo) mSectionsPagerAdapter.getItem(tabLayout.getSelectedTabPosition());

--- a/app/src/main/java/uk/ac/coventry/a260ct/orks/slopemanager/SlopeDatabase.java
+++ b/app/src/main/java/uk/ac/coventry/a260ct/orks/slopemanager/SlopeDatabase.java
@@ -66,6 +66,15 @@ public class SlopeDatabase extends SQLiteOpenHelper {
     private static final String COL_BOOKING_ID = "booking_id";
     private static final String COL_PAID = "paid";
 
+    //Hashmap for permission table
+  private static final HashMap<Integer,String> hashForTypeOfUsers;
+    static{
+        hashForTypeOfUsers=new HashMap<>();
+        hashForTypeOfUsers.put(0,"NormalUser");
+        hashForTypeOfUsers.put(1,"Member");
+        hashForTypeOfUsers.put(2,"SlopeOperator");
+    }
+
 
 
 
@@ -355,15 +364,19 @@ public class SlopeDatabase extends SQLiteOpenHelper {
         return (int) db.insert(SESSIONS_TABLE, null, values);
     }
 
-    public User getUserFromId(int id,String type) {
+    public User getUserFromId(int id) {
         String query = "SELECT * FROM " + USERS_TABLE + " WHERE " + COL_ID + "=?";
         UserFactory factory=new UserFactory();
         HashMap<String,String>map=new HashMap<>();
         Cursor cursor = db.rawQuery(query, new String[]{String.valueOf(id)});
         User user = null;
+        int permission=-1;
 
         if (cursor != null) {
             if (cursor.moveToFirst()) {
+                               //get the right permission so that factory can generate the correct user
+                                permission=cursor.getInt(cursor.getColumnIndex(COL_MEMBERSHIP));
+                                //put details of the user in hashmap.
                                 map.put("ID",cursor.getString(cursor.getColumnIndex(COL_ID)));
                                 map.put("firstName",cursor.getString(cursor.getColumnIndex(COL_FIRST_NAME)));
                                 map.put("surname",cursor.getString(cursor.getColumnIndex(COL_LAST_NAME)));
@@ -373,7 +386,7 @@ public class SlopeDatabase extends SQLiteOpenHelper {
                 cursor.close();
             }
         }
-        user=factory.getUser(type,map);
+        user=factory.getUser(hashForTypeOfUsers.get(permission),map);
         return user;
     }
 

--- a/app/src/main/java/uk/ac/coventry/a260ct/orks/slopemanager/UserFactory.java
+++ b/app/src/main/java/uk/ac/coventry/a260ct/orks/slopemanager/UserFactory.java
@@ -19,7 +19,7 @@ public class UserFactory {
             case "SlopeOperator":
                  user=new SlopeOperator(userDetails);
                 break;
-            case "normalUser":
+            case "NormalUser":
                 user = new NormalUser(userDetails);
                 break;
 

--- a/app/src/main/res/layout/activity_login_layout.xml
+++ b/app/src/main/res/layout/activity_login_layout.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:app2=""
+
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/activity_login_layout"
     android:layout_width="match_parent"


### PR DESCRIPTION
reverted to the first way of retrieving the user using only his id
without specifying the type of user as this can be detected at runtime
from the “permission” field of the retrieved user
For #5 